### PR TITLE
Add GPU support for mac, multi gpu for linux

### DIFF
--- a/.github/workflows/cargo.yaml
+++ b/.github/workflows/cargo.yaml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/cargo.yaml
+++ b/.github/workflows/cargo.yaml
@@ -61,4 +61,5 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          # TODO: fix warnings and enable this
+          # args: -- -D warnings

--- a/.github/workflows/cargo.yaml
+++ b/.github/workflows/cargo.yaml
@@ -7,59 +7,49 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: actions/checkout@v3
+      - name: Install Rust (Stable)
+        run: |
+          curl -sSL https://sh.rustup.rs | sh -s -- -y
+          rustup default stable
+      - name: Cargo Check
+        run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v3
+      - name: Install Rust (Stable)
+        run: |
+          curl -sSL https://sh.rustup.rs | sh -s -- -y
+          rustup default stable
+      - name: Cargo Test
+        run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v3
+      - name: Install Rust (Stable)
+        run: |
+          curl -sSL https://sh.rustup.rs | sh -s -- -y
+          rustup default stable
+      - name: Cargo Fmt
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          # TODO: fix warnings and enable this
-          # args: -- -D warnings
+      - uses: actions/checkout@v3
+      - name: Install Rust (Stable)
+        run: |
+          curl -sSL https://sh.rustup.rs | sh -s -- -y
+          rustup default stable
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Cargo Clippy
+        # TODO: fix warnings and enable
+        run: cargo clippy # -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +356,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "rustix"
 version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +578,8 @@ name = "zeitfetch"
 version = "0.1.6"
 dependencies = [
  "home",
+ "lazy_static",
  "prettytable-rs",
+ "regex",
  "sysinfo",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,31 @@ name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -581,5 +606,7 @@ dependencies = [
  "lazy_static",
  "prettytable-rs",
  "regex",
+ "serde",
+ "serde_json",
  "sysinfo",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ home = "0.5.3"
 lazy_static = "1.4.0"
 prettytable-rs = "^0.10"
 regex = "1.7.3"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = "1.0.95"
 sysinfo = "0.28.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ homepage = "https://github.com/nidnogg/zeitfetch"
 readme = "README.md"
 
 [dependencies]
-sysinfo = "0.28.2"
 home = "0.5.3"
+lazy_static = "1.4.0"
 prettytable-rs = "^0.10"
+regex = "1.7.3"
+sysinfo = "0.28.2"

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -407,4 +407,87 @@ mod tests {
         let gpu = cap.and_then(|c| c.name("gpu").map(|m| m.as_str()));
         assert_eq!(gpu, Some("GA107M [GeForce RTX 3050 Ti Mobile]"));
     }
+
+    #[test]
+    fn parse_lspci_mm_output() {
+        let input = r#"00:00.0 "Host bridge" "Intel Corporation" "12th Gen Core Processor Host Bridge/DRAM Registers" -r02 -p00 "Dell" "Device 0b19"
+00:01.0 "PCI bridge" "Intel Corporation" "12th Gen Core Processor PCI Express x16 Controller #1" -r02 -p00 "Dell" "Device 0b19"
+00:02.0 "VGA compatible controller" "Intel Corporation" "Alder Lake-P Integrated Graphics Controller" -r0c -p00 "Dell" "Device 0b19"
+00:04.0 "Signal processing controller" "Intel Corporation" "Alder Lake Innovation Platform Framework Processor Participant" -r02 -p00 "Dell" "Device 0b19"
+00:06.0 "PCI bridge" "Intel Corporation" "12th Gen Core Processor PCI Express x4 Controller #0" -r02 -p00 "Dell" "Device 0b19"
+00:07.0 "PCI bridge" "Intel Corporation" "Alder Lake-P Thunderbolt 4 PCI Express Root Port #0" -r02 -p00 "Dell" "Device 0b19"
+00:07.1 "PCI bridge" "Intel Corporation" "Alder Lake-P Thunderbolt 4 PCI Express Root Port #1" -r02 -p00 "Dell" "Device 0b19"
+00:08.0 "System peripheral" "Intel Corporation" "12th Gen Core Processor Gaussian & Neural Accelerator" -r02 -p00 "Dell" "Device 0b19"
+00:0d.0 "USB controller" "Intel Corporation" "Alder Lake-P Thunderbolt 4 USB Controller" -r02 -p30 "Dell" "Device 0b19"
+00:0d.2 "USB controller" "Intel Corporation" "Alder Lake-P Thunderbolt 4 NHI #0" -r02 -p40 "Dell" "Device 0b19"
+00:12.0 "Serial controller" "Intel Corporation" "Alder Lake-P Integrated Sensor Hub" -r01 -p00 "Dell" "Device 0b19"
+00:14.0 "USB controller" "Intel Corporation" "Alder Lake PCH USB 3.2 xHCI Host Controller" -r01 -p30 "Dell" "Device 0b19"
+00:14.2 "RAM memory" "Intel Corporation" "Alder Lake PCH Shared SRAM" -r01 -p00 "Dell" "Device 0b19"
+00:14.3 "Network controller" "Intel Corporation" "Alder Lake-P PCH CNVi WiFi" -r01 -p00 "Intel Corporation" "Wi-Fi 6E AX211 160MHz"
+00:15.0 "Serial bus controller" "Intel Corporation" "Alder Lake PCH Serial IO I2C Controller #0" -r01 -p00 "Dell" "Device 0b19"
+00:15.1 "Serial bus controller" "Intel Corporation" "Alder Lake PCH Serial IO I2C Controller #1" -r01 -p00 "Dell" "Device 0b19"
+00:16.0 "Communication controller" "Intel Corporation" "Alder Lake PCH HECI Controller" -r01 -p00 "Dell" "Device 0b19"
+00:1c.0 "PCI bridge" "Intel Corporation" "Device 51bb" -r01 -p00 "Dell" "Device 0b19"
+00:1f.0 "ISA bridge" "Intel Corporation" "Alder Lake PCH eSPI Controller" -r01 -p00 "Dell" "Device 0b19"
+00:1f.3 "Audio device" "Intel Corporation" "Alder Lake PCH-P High Definition Audio Controller" -r01 -p80 "Dell" "Device 0b19"
+00:1f.4 "SMBus" "Intel Corporation" "Alder Lake PCH-P SMBus Host Controller" -r01 -p00 "Dell" "Device 0b19"
+00:1f.5 "Serial bus controller" "Intel Corporation" "Alder Lake-P PCH SPI Controller" -r01 -p00 "Dell" "Device 0b19"
+01:00.0 "3D controller" "NVIDIA Corporation" "GA107M [GeForce RTX 3050 Ti Mobile]" -ra1 -p00 "Dell" "Device 0b19"
+02:00.0 "Non-Volatile memory controller" "Samsung Electronics Co Ltd" "NVMe SSD Controller PM9A1/PM9A3/980PRO" -p02 "Samsung Electronics Co Ltd" "Device a801"
+54:00.0 "PCI bridge" "Intel Corporation" "JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018]" -r06 -p00 "Intel Corporation" "Device 0000"
+55:02.0 "PCI bridge" "Intel Corporation" "JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018]" -r06 -p00 "Intel Corporation" "Device 0000"
+55:04.0 "PCI bridge" "Intel Corporation" "JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018]" -r06 -p00 "Intel Corporation" "Device 0000"
+56:00.0 "USB controller" "Intel Corporation" "JHL7540 Thunderbolt 3 USB Controller [Titan Ridge DD 2018]" -r06 -p30 "Intel Corporation" "Device 0000"
+a5:00.0 "Unassigned class [ff00]" "Realtek Semiconductor Co., Ltd." "RTS5260 PCI Express Card Reader" -r01 -p00 "Dell" "Device 0b19"
+"#;
+        assert_eq!(
+            super::parse_lspci_mm_output(input.as_bytes()),
+            vec![
+                "Alder Lake-P Integrated Graphics Controller",
+                "GA107M [GeForce RTX 3050 Ti Mobile]"
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_system_profiler_json_output() {
+        let input = r#"{
+  "SPDisplaysDataType" : [
+    {
+      "_name" : "kHW_AppleM1Item",
+      "spdisplays_mtlgpufamilysupport" : "spdisplays_metal3",
+      "spdisplays_ndrvs" : [
+        {
+          "_name" : "Color LCD",
+          "_spdisplays_display-product-id" : "a047",
+          "_spdisplays_display-serial-number" : "---redacted---",
+          "_spdisplays_display-vendor-id" : "610",
+          "_spdisplays_display-week" : "0",
+          "_spdisplays_display-year" : "0",
+          "_spdisplays_displayID" : "1",
+          "_spdisplays_pixels" : "2880 x 1800",
+          "_spdisplays_resolution" : "1440 x 900 @ 60.00Hz",
+          "spdisplays_ambient_brightness" : "spdisplays_yes",
+          "spdisplays_connection_type" : "spdisplays_internal",
+          "spdisplays_display_type" : "spdisplays_built-in_retinaLCD",
+          "spdisplays_main" : "spdisplays_yes",
+          "spdisplays_mirror" : "spdisplays_off",
+          "spdisplays_online" : "spdisplays_yes",
+          "spdisplays_pixelresolution" : "spdisplays_2560x1600Retina"
+        }
+      ],
+      "spdisplays_vendor" : "sppci_vendor_Apple",
+      "sppci_bus" : "spdisplays_builtin",
+      "sppci_cores" : "7",
+      "sppci_device_type" : "spdisplays_gpu",
+      "sppci_model" : "Apple M1"
+    }
+  ]
+}
+"#;
+        assert_eq!(
+            super::parse_system_profiler_json_output(input.as_bytes()),
+            vec!["Apple M1"],
+        );
+    }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -376,3 +376,21 @@ fn get_mac_friendly_name(untrimmed_ver_num: String) -> String {
 
     format!("{} {}", friendly_name, ver_num)
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn gpu_regex_empty() {
+        use crate::scanner::GPU_RE;
+        let cap = GPU_RE.captures("");
+        assert!(cap.is_none());
+    }
+
+    #[test]
+    fn gpu_regex_nvidia() {
+        use crate::scanner::GPU_RE;
+        let cap = GPU_RE.captures(r#"01:00.0 "3D controller" "NVIDIA Corporation" "GA107M [GeForce RTX 3050 Ti Mobile]" -ra1 -p00 "Dell" "Device 0b19""#);
+        let gpu = cap.and_then(|c| c.name("gpu").map(|m| m.as_str()));
+        assert_eq!(gpu, Some("GA107M [GeForce RTX 3050 Ti Mobile]"));
+    }
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -10,11 +10,13 @@ use sysinfo::{CpuExt, System, SystemExt};
 
 use crate::logo::*;
 
+/// Data for a single display from the `system_profiler` command
 #[derive(Serialize, Deserialize, Debug)]
 struct SPDisplay {
     sppci_model: String,
 }
 
+/// Output of macOS's `system_profiler SPDisplayDataType` command
 #[derive(Serialize, Deserialize, Debug)]
 struct SPDisplays {
     #[serde(rename = "SPDisplaysDataType")]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -387,6 +387,13 @@ mod tests {
     }
 
     #[test]
+    fn gpu_regex_not_gpu() {
+        use crate::scanner::GPU_RE;
+        let cap = GPU_RE.captures(r#"00:00.0 "Host bridge" "Intel Corporation" "12th Gen Core Processor Host Bridge/DRAM Registers" -r02 -p00 "Dell" "Device 0b19""#);
+        assert!(cap.is_none());
+    }
+
+    #[test]
     fn gpu_regex_nvidia() {
         use crate::scanner::GPU_RE;
         let cap = GPU_RE.captures(r#"01:00.0 "3D controller" "NVIDIA Corporation" "GA107M [GeForce RTX 3050 Ti Mobile]" -ra1 -p00 "Dell" "Device 0b19""#);


### PR DESCRIPTION
Used [system_profiler](https://ss64.com/osx/system_profiler.html) to obtain the GPU name in macOS. I've only tested it on a M1 MacBook Air, it givs the output "Apple M1".

For linux, I dug a little into the data that lspci gives back instead of just presenting the entire line. On my machine, it previously gave:
```
GPU: 01:00.0 3D controller: NVIDIA Corporation GA107M [GeForce RTX 3050 Ti Mobile] (rev a1)
```
But now it is just
```
GPU: GA107M [GeForce RTX 3050 Ti Mobile]
```
which I think is more in line with what users expect.

Also, in both macOS and linux, multiple gpus will be returned if the respective commands detect them.

You can see this in the screenshot from my system where the new behaviour is on top, and the old is below.
![2023-04-08T10:33:48,344141774+10:00](https://user-images.githubusercontent.com/11096602/230695591-d5703952-4f8e-4685-a6ea-ca9dfddef224.png)

### Some implementations notes
I used serde_json to parse the output of `system_profiler`, but a regex for `lspci -mm`. This could be improved by finding an approproite parser for the ouput of `lspci -mm`, but it's a mixture of quoted and unquoted space seperated fields. Perhaps some csv style parser will work, but I didn't try too hard to find one. According to the [man](https://man7.org/linux/man-pages/man8/lspci.8.html#MACHINE_READABLE_OUTPUT), the fields are quoted "if necessary". So, the regex implementation will break if some of the quoted fields are not quoted. However, I think we can ship this and fix it if we find reports of failure.

To allow mutiple GPUs, I collected the gpu names into a vector and then joined them with a newline separator. There is no need to allocate that vecotor, but I think it's a microoptimisation to improve it. It's highly likely that the number of GPUs is one or two, so improveing this is not going to yeild a massive performance improvement.
