### PR TITLE
Truncate output on narrow terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +275,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hermit-abi"
@@ -318,6 +419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -415,6 +528,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "relative-path"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
 name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +638,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -691,6 +863,7 @@ dependencies = [
  "lazy_static",
  "prettytable-rs",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "sysinfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,4 +615,5 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "unicode-segmentation",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +425,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +509,21 @@ checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -641,12 +704,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -861,11 +949,14 @@ version = "0.1.8"
 dependencies = [
  "home",
  "lazy_static",
+ "phf",
  "prettytable-rs",
  "regex",
  "rstest",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sysinfo",
  "termsize",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +134,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -172,6 +183,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -191,7 +211,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -222,6 +242,16 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "lazy_static"
@@ -262,7 +292,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -274,6 +304,12 @@ dependencies = [
  "hermit-abi 0.2.6",
  "libc",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
@@ -343,6 +379,12 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -458,7 +500,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -469,7 +511,32 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
+name = "termsize"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e86d824a8e90f342ad3ef4bd51ef7119a9b681b0cc9f8ee7b2852f02ccd2517"
+dependencies = [
+ "atty",
+ "kernel32-sys",
+ "libc",
+ "termion",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -518,6 +585,12 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -525,6 +598,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -615,5 +694,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "termsize",
  "unicode-segmentation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = "1.0.95"
 sysinfo = "0.28.2"
 termsize = "0.1.6"
 unicode-segmentation = "1.10.1"
+
+[dev-dependencies]
+rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ regex = "1.7.3"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 sysinfo = "0.28.2"
+unicode-segmentation = "1.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ regex = "1.7.3"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 sysinfo = "0.28.2"
+termsize = "0.1.6"
 unicode-segmentation = "1.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ readme = "README.md"
 [dependencies]
 home = "0.5.3"
 lazy_static = "1.4.0"
+phf = { version = "0.11.2", features = ["macros"] }
 prettytable-rs = "^0.10"
 regex = "1.7.3"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
+strum = "0.25.0"
+strum_macros = "0.25.3"
 sysinfo = "0.28.2"
 termsize = "0.1.6"
 unicode-segmentation = "1.10.1"

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,0 +1,64 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+// truncate a string ignore ANSI graphics
+pub fn truncate(s: &str, n: usize) -> String {
+    let mut count = 0;
+    let mut out = String::new();
+    let mut in_ansi = false;
+    for g in s.graphemes(true) {
+        if count >= n {
+            break;
+        }
+        if g == "\x1b" {
+            in_ansi = true;
+        } else if g == "m" && in_ansi {
+            in_ansi = false;
+        } else {
+            if !in_ansi {
+                count += 1;
+            }
+        }
+        out.push_str(g)
+    }
+    out.to_string()
+}
+
+// length of string ignoreing ANSI graphics
+pub fn len(s: &str) -> usize {
+    let mut count = 0;
+    let mut in_ansi = false;
+    for g in s.graphemes(true) {
+        if g == "\x1b" {
+            in_ansi = true;
+        } else if g == "m" && in_ansi {
+            in_ansi = false;
+        } else if !in_ansi {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_truncate_plain() {
+        assert_eq!(super::truncate("hello", 3), "hel");
+        assert_eq!(super::truncate("hello", 5), "hello");
+        assert_eq!(super::truncate("hello", 6), "hello");
+    }
+
+    #[test]
+    fn test_truncate_ansi() {
+        // TODO: ensure reset at end
+        assert_eq!(super::truncate("\x1b[1mhello\x1b[0m", 3), "\x1b[1mhel");
+        assert_eq!(
+            super::truncate("\x1b[1mhello\x1b[0m", 5),
+            "\x1b[1mhello\x1b[0m"
+        );
+        assert_eq!(
+            super::truncate("\x1b[1mhello\x1b[0m", 6),
+            "\x1b[1mhello\x1b[0m"
+        );
+    }
+}

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -43,7 +43,8 @@ pub fn truncate(s: &str, n: usize) -> String {
         }
         out.push_str(g)
     }
-    out.to_string()
+
+    out
 }
 
 #[cfg(test)]

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,7 +1,7 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-// truncate a string, ignoring ANSI graphics. This will preserve trailing ANSI
-// graphics past the truncation point.
+/// Truncate a string, ignoring ANSI graphics, but preserving trailing ANSI
+/// graphics past the truncation point.
 pub fn truncate(s: &str, n: usize) -> String {
     #[derive(Debug, PartialEq, Eq)]
     enum State {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,8 +1,8 @@
-use unicode_segmentation::UnicodeSegmentation;
-
 /// Truncate a string, ignoring ANSI graphics, but preserving trailing ANSI
 /// graphics past the truncation point.
 pub fn truncate(s: &str, n: usize) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+
     #[derive(Debug, PartialEq, Eq)]
     enum State {
         Normal,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ const ASCII_LOGO: &str = r"
 ";
 pub struct Ctx {
     pub args: Args,
+    pub width: usize,
 }
 
 #[derive(Debug, Default)]
@@ -23,7 +24,8 @@ pub struct Args {
 impl Ctx {
     pub fn new() -> Self {
         let args = Args::parse_args();
-        Ctx { args }
+        let width = termsize::get().map(|w| w.cols).unwrap_or(80).into();
+        Ctx { width, args }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ const ASCII_LOGO: &str = r"
 ";
 pub struct Ctx {
     pub args: Args,
-    pub width: usize,
+    pub width: Option<usize>,
 }
 
 #[derive(Debug, Default)]
@@ -24,7 +24,7 @@ pub struct Args {
 impl Ctx {
     pub fn new() -> Self {
         let args = Args::parse_args();
-        let width = termsize::get().map(|w| w.cols).unwrap_or(80).into();
+        let width = termsize::get().map(|w| w.cols.into());
         Ctx { width, args }
     }
 }

--- a/src/logo.rs
+++ b/src/logo.rs
@@ -2,22 +2,22 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
     match sys_name {
         "deb" => String::from(
             "
-\x1b[1m       _,.ss$$$$$gg.
-\x1b[1m    ,g$$$$$$$$$$$$$$$P.
-\x1b[1m  ,g$$P`'     ```Y$$.`.
-\x1b[1m ,$$P''              `$$$.
-\x1b[1m',$$P       ,ggs.     `$$b:
-\x1b[1m`d$$'     ,$P`'   \x1b[91;1m.\x1b[0m    $$$
-\x1b[1m$$P'      d$'     \x1b[91;1m,\x1b[0m    $$P
-\x1b[1m$$:      $$.   \x1b[91;1m-\x1b[0m    ,d$$`
-\x1b[1m$$;      Y$b._   _,d$P'
-\x1b[1mY$$.    \x1b[91;1m`.\x1b[0m``Y$$$$P`'
+\x1b[1m       _,.ss$$$$$gg.\x1b[0m
+\x1b[1m    ,g$$$$$$$$$$$$$$$P.\x1b[0m
+\x1b[1m  ,g$$P`'     ```Y$$.`.\x1b[0m
+\x1b[1m ,$$P''              `$$$.\x1b[0m
+\x1b[1m',$$P       ,ggs.     `$$b:\x1b[0m
+\x1b[1m`d$$'     ,$P`'   \x1b[91;1m.\x1b[0m    $$$\x1b[0m
+\x1b[1m$$P'      d$'     \x1b[91;1m,\x1b[0m    $$P\x1b[0m
+\x1b[1m$$:      $$.   \x1b[91;1m-\x1b[0m    ,d$$`\x1b[0m
+\x1b[1m$$;      Y$b._   _,d$P'\x1b[0m
+\x1b[1mY$$.    \x1b[91;1m`.\x1b[0m``Y$$$$P`'\x1b[0m
 \x1b[1m`$$b      \x1b[91;1m`\"-.__\x1b[0m
-\x1b[1m `Y$$
-\x1b[1m  `Y$$.
-\x1b[1m    `$$b.
-\x1b[1m       `Y$$b.
-\x1b[1m          ``Y$b._
+\x1b[1m `Y$$\x1b[0m
+\x1b[1m  `Y$$.\x1b[0m
+\x1b[1m    `$$b.\x1b[0m
+\x1b[1m       `Y$$b.\x1b[0m
+\x1b[1m          ``Y$b._\x1b[0m
 \x1b[1m              ```\x1b[0m
             ",
         ),
@@ -27,11 +27,11 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[1m                yyyyy- \x1b[91;1m-yyyyyy+\x1b[0m
 \x1b[1m             ://+//////\x1b[91;1m-yyyyyyo\x1b[0m
 \x1b[1m         \x1b[93;1m.++\x1b[0m .:/++++++/-.+sss/`\x1b[0m
-\x1b[1m       \x1b[93;1m.:++o:\x1b[0m  /++++++++/:--:/-
-\x1b[1m      \x1b[93;1mo:+o+:++.\x1b[0m`..```.-/oo+++++/
-\x1b[1m     \x1b[93;1m.:+o:+o/.\x1b[0m          `+sssoo+/
-\x1b[1m.++/+:\x1b[93;1m+oo+o:`\x1b[0m             /sssooo.
-\x1b[1m/+++//+:\x1b[93;1m`oo+o\x1b[0m               /::--:.
+\x1b[1m       \x1b[93;1m.:++o:\x1b[0m  /++++++++/:--:/-\x1b[0m
+\x1b[1m      \x1b[93;1mo:+o+:++.\x1b[0m`..```.-/oo+++++/\x1b[0m
+\x1b[1m     \x1b[93;1m.:+o:+o/.\x1b[0m          `+sssoo+/\x1b[0m
+\x1b[1m.++/+:\x1b[93;1m+oo+o:`\x1b[0m             /sssooo.\x1b[0m
+\x1b[1m/+++//+:\x1b[93;1m`oo+o\x1b[0m               /::--:.\x1b[0m
 \x1b[1m\\+/+o+++\x1b[93;1m`o++o\x1b[0m               \x1b[91;1m++////.\x1b[0m
 \x1b[1m .++.o+\x1b[93;1m++oo+:`\x1b[0m             \x1b[91;1m/dddhhh.\x1b[0m
 \x1b[1m      \x1b[93;1m.+.o+oo:.\x1b[0m          \x1b[91;1m`oddhhhh+\x1b[0m
@@ -45,141 +45,138 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
         ),
         "fedora" => String::from(
             "
-\x1b[94;1m             .',;::::;,'.
-\x1b[94;1m         .';:cccccccccccc:;,.
-\x1b[94;1m      .;cccccccccccccccccccccc;.
-\x1b[94;1m    .:cccccccccccccccccccccccccc:.
-\x1b[94;1m  .;ccccccccccccc;\x1b[0m.:dddl:.\x1b[94;1m;ccccccc;.
-\x1b[94;1m .:ccccccccccccc;\x1b[0mOWMKOOXMWd\x1b[94;1m;ccccccc:.
-\x1b[94;1m.:ccccccccccccc;\x1b[0mKMMc\x1b[94;1m;cc;\x1b[0mxMMc\x1b[94;1m:ccccccc:.
-\x1b[94;1m,cccccccccccccc;\x1b[0mMMM.\x1b[94;1m;cc;\x1b[0m;WW:\x1b[94;1m:cccccccc,
-\x1b[94;1m:cccccccccccccc;\x1b[0mMMM.\x1b[94;1m;cccccccccccccccc:
-\x1b[94;1m:ccccccc;\x1b[0moxOOOo\x1b[94;1m;\x1b[0mMMM0OOk.\x1b[94;1m;cccccccccccc:
-\x1b[94;1mcccccc:\x1b[0m0MMKxdd:\x1b[94;1m;\x1b[0mMMMkddc.\x1b[94;1m;cccccccccccc;
-\x1b[94;1mccccc:\x1b[0mXM0'\x1b[94;1m;cccc;\x1b[0mMMM.\x1b[94;1m;cccccccccccccccc'
-\x1b[94;1mccccc;\x1b[0mMMo\x1b[94;1m;ccccc;\x1b[0mMMW.\x1b[94;1m;ccccccccccccccc;
-\x1b[94;1mccccc;\x1b[0m0MNc.\x1b[94;1mccc\x1b[0m.xMMd\x1b[94;1m:ccccccccccccccc;
-\x1b[94;1mcccccc;\x1b[0mdNMWXXXWM0:\x1b[94;1m:cccccccccccccc:,
-\x1b[94;1mcccccccc;\x1b[0m.:odl:.\x1b[94;1m;cccccccccccccc:,.
-\x1b[94;1m:cccccccccccccccccccccccccccc:'.
-\x1b[94;1m.:cccccccccccccccccccccc:;,..
+\x1b[94;1m             .',;::::;,'.\x1b[0m
+\x1b[94;1m         .';:cccccccccccc:;,.\x1b[0m
+\x1b[94;1m      .;cccccccccccccccccccccc;.\x1b[0m
+\x1b[94;1m    .:cccccccccccccccccccccccccc:.\x1b[0m
+\x1b[94;1m  .;ccccccccccccc;\x1b[0m.:dddl:.\x1b[94;1m;ccccccc;.\x1b[0m
+\x1b[94;1m .:ccccccccccccc;\x1b[0mOWMKOOXMWd\x1b[94;1m;ccccccc:.\x1b[0m
+\x1b[94;1m.:ccccccccccccc;\x1b[0mKMMc\x1b[94;1m;cc;\x1b[0mxMMc\x1b[94;1m:ccccccc:.\x1b[0m
+\x1b[94;1m,cccccccccccccc;\x1b[0mMMM.\x1b[94;1m;cc;\x1b[0m;WW:\x1b[94;1m:cccccccc,\x1b[0m
+\x1b[94;1m:cccccccccccccc;\x1b[0mMMM.\x1b[94;1m;cccccccccccccccc:\x1b[0m
+\x1b[94;1m:ccccccc;\x1b[0moxOOOo\x1b[94;1m;\x1b[0mMMM0OOk.\x1b[94;1m;cccccccccccc:\x1b[0m
+\x1b[94;1mcccccc:\x1b[0m0MMKxdd:\x1b[94;1m;\x1b[0mMMMkddc.\x1b[94;1m;cccccccccccc;\x1b[0m
+\x1b[94;1mccccc:\x1b[0mXM0'\x1b[94;1m;cccc;\x1b[0mMMM.\x1b[94;1m;cccccccccccccccc'\x1b[0m
+\x1b[94;1mccccc;\x1b[0mMMo\x1b[94;1m;ccccc;\x1b[0mMMW.\x1b[94;1m;ccccccccccccccc;\x1b[0m
+\x1b[94;1mccccc;\x1b[0m0MNc.\x1b[94;1mccc\x1b[0m.xMMd\x1b[94;1m:ccccccccccccccc;\x1b[0m
+\x1b[94;1mcccccc;\x1b[0mdNMWXXXWM0:\x1b[94;1m:cccccccccccccc:,\x1b[0m
+\x1b[94;1mcccccccc;\x1b[0m.:odl:.\x1b[94;1m;cccccccccccccc:,.\x1b[0m
+\x1b[94;1m:cccccccccccccccccccccccccccc:'.\x1b[0m
+\x1b[94;1m.:cccccccccccccccccccccc:;,..\x1b[0m
 \x1b[94;1m  '::cccccccccccccc::;,.\x1b[0m",
         ),
         "mac" => String::from(
             "
-\x1b[92;1m                   'c.
-\x1b[92;1m                ,xNMM.
-\x1b[92;1m              .OMMMMo
-\x1b[92;1m              OMMM0,
-\x1b[92;1m    .;loddo:' loolloddol;.
-\x1b[92;1m  cKMMMMMMMMMMNWMMMMMMMMMM0:
-\x1b[93;1m.KMMMMMMMMMMMMMMMMMMMMMMMWd.
-\x1b[93;1mXMMMMMMMMMMMMMMMMMMMMMMMX.
-\x1b[91;1m;MMMMMMMMMMMMMMMMMMMMMMMM:
-\x1b[91;1m:MMMMMMMMMMMMMMMMMMMMMMMM:
-\x1b[91;1m.MMMMMMMMMMMMMMMMMMMMMMMMX.
-\x1b[91;1mkMMMMMMMMMMMMMMMMMMMMMMMMWd.
-\x1b[95;1m.XMMMMMMMMMMMMMMMMMMMMMMMMMMk
-\x1b[95;1m .XMMMMMMMMMMMMMMMMMMMMMMMMK.
-\x1b[94;1m   kMMMMMMMMMMMMMMMMMMMMMMd
-\x1b[94;1m    ;KMMMMMMMWXXWMMMMMMMk.
+\x1b[92;1m                   'c.\x1b[0m
+\x1b[92;1m                ,xNMM.\x1b[0m
+\x1b[92;1m              .OMMMMo\x1b[0m
+\x1b[92;1m              OMMM0,\x1b[0m
+\x1b[92;1m    .;loddo:' loolloddol;.\x1b[0m
+\x1b[92;1m  cKMMMMMMMMMMNWMMMMMMMMMM0:\x1b[0m
+\x1b[93;1m.KMMMMMMMMMMMMMMMMMMMMMMMWd.\x1b[0m
+\x1b[93;1mXMMMMMMMMMMMMMMMMMMMMMMMX.\x1b[0m
+\x1b[91;1m;MMMMMMMMMMMMMMMMMMMMMMMM:\x1b[0m
+\x1b[91;1m:MMMMMMMMMMMMMMMMMMMMMMMM:\x1b[0m
+\x1b[91;1m.MMMMMMMMMMMMMMMMMMMMMMMMX.\x1b[0m
+\x1b[91;1mkMMMMMMMMMMMMMMMMMMMMMMMMWd.\x1b[0m
+\x1b[95;1m.XMMMMMMMMMMMMMMMMMMMMMMMMMMk\x1b[0m
+\x1b[95;1m .XMMMMMMMMMMMMMMMMMMMMMMMMK.\x1b[0m
+\x1b[94;1m   kMMMMMMMMMMMMMMMMMMMMMMd\x1b[0m
+\x1b[94;1m    ;KMMMMMMMWXXWMMMMMMMk.\x1b[0m
 \x1b[94;1m      .cooc,.    .,coo:.\x1b[0m
                 ",
         ),
         "win11" => String::from(
             "
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
-\x1b[34;1mlllllllllllllll   lllllllllllllll
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
-    ",
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
+\x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m",
         ),
         "win" => String::from(
             "
-\x1b[34m                  .oodMMMMMMMMMMMMM
-\x1b[34m      ..oodMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34moodMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
+\x1b[34m                  .oodMMMMMMMMMMMM\x1b[0m
+\x1b[34m      ..oodMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34moodMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
 
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34m`^^^^^^MMMMMMM  MMMMMMMMMMMMMMMMMMM
-\x1b[34m    ````^^^^  ^^MMMMMMMMMMMMMMMMMMM
-\x1b[34m                   ````^^^^^^MMMMMM\x1b[0m
-    ",
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34mMMMMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34m`^^^^^^MMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34m    ````^^^^  ^^MMMMMMMMMMMMMMMMMM\x1b[0m
+\x1b[34m                  ````^^^^^^MMMMMM\x1b[0m",
         ),
         "arch" => String::from(
             "
- \x1b[94;1m                 ##
- \x1b[94;1m                ####
- \x1b[94;1m               ######
- \x1b[94;1m              ########
- \x1b[94;1m             ##########
- \x1b[94;1m            ############
- \x1b[94;1m           ##############
- \x1b[94;1m          ################
- \x1b[94;1m         ##################
- \x1b[94;1m        ####################
- \x1b[94;1m       ######################
- \x1b[94;1m      #########      #########
- \x1b[94;1m     ##########      ##########
- \x1b[94;1m    ###########      ###########
- \x1b[94;1m   ##########          ##########
- \x1b[94;1m  #######                  #######
- \x1b[94;1m ####                          ####
+ \x1b[94;1m                 ##                 \x1b[0m
+ \x1b[94;1m                ####                \x1b[0m
+ \x1b[94;1m               ######               \x1b[0m
+ \x1b[94;1m              ########              \x1b[0m
+ \x1b[94;1m             ##########             \x1b[0m
+ \x1b[94;1m            ############            \x1b[0m
+ \x1b[94;1m           ##############           \x1b[0m
+ \x1b[94;1m          ################          \x1b[0m
+ \x1b[94;1m         ##################         \x1b[0m
+ \x1b[94;1m        ####################        \x1b[0m
+ \x1b[94;1m       ######################       \x1b[0m
+ \x1b[94;1m      #########      #########      \x1b[0m
+ \x1b[94;1m     ##########      ##########     \x1b[0m
+ \x1b[94;1m    ###########      ###########    \x1b[0m
+ \x1b[94;1m   ##########          ##########   \x1b[0m
+ \x1b[94;1m  #######                  #######  \x1b[0m
+ \x1b[94;1m ####                          #### \x1b[0m
  \x1b[94;1m###                              ###\x1b[0m",
         ),
         "redhat" => String::from(
             "
-\x1b[31;1m
-\x1b[31;1m             ..   .:..
-\x1b[31;1m           .:::::::::::::..
-\x1b[31;1m           :::::::::::::::::
-\x1b[31;1m          :::::::::::::::::::
-\x1b[31;1m          .::::::::::::::::::
-\x1b[31;1m   .:::::   .:::::::::::::::::
-\x1b[31;1m  .:::::::     ..::::::::::::.
-\x1b[31;1m   :::::::::.         ....    .::.
-\x1b[31;1m    .::::::::::..            .:::::
-\x1b[31;1m      .::::::::::::::::::::::::::::.
-\x1b[31;1m         .:::::::::::::::::::::::::
-\x1b[31;1m             ..::::::::::::::::::.
-\x1b[31;1m                  ....:::::...
-\x1b[31;1m
-",
+\x1b[31;1m\x1b[0m
+\x1b[31;1m             ..   .:..\x1b[0m
+\x1b[31;1m           .:::::::::::::..\x1b[0m
+\x1b[31;1m           :::::::::::::::::\x1b[0m
+\x1b[31;1m          :::::::::::::::::::\x1b[0m
+\x1b[31;1m          .::::::::::::::::::\x1b[0m
+\x1b[31;1m   .:::::   .:::::::::::::::::\x1b[0m
+\x1b[31;1m  .:::::::     ..::::::::::::.\x1b[0m
+\x1b[31;1m   :::::::::.         ....    .::.\x1b[0m
+\x1b[31;1m    .::::::::::..            .:::::\x1b[0m
+\x1b[31;1m      .::::::::::::::::::::::::::::.\x1b[0m
+\x1b[31;1m         .:::::::::::::::::::::::::\x1b[0m
+\x1b[31;1m             ..::::::::::::::::::.\x1b[0m
+\x1b[31;1m                  ....:::::...\x1b[0m
+\x1b[31;1m\x1b[0m",
         ),
         "linux" => String::from(
             "
-\x1b[1m        a8888b.
-\x1b[1m       d888888b.
-\x1b[1m       8P\"YP\"Y88
-\x1b[1m       8|o||o|88
+\x1b[1m        a8888b.\x1b[0m
+\x1b[1m       d888888b.\x1b[0m
+\x1b[1m       8P\"YP\"Y88\x1b[0m
+\x1b[1m       8|o||o|88\x1b[0m
 \x1b[1m       8\x1b[93;1m'    .\x1b[0m88
 \x1b[1m       8\x1b[93;1m`._.'\x1b[0m Y8.
-\x1b[1m      d/      `8b.
-\x1b[1m     dP        Y8b.
-\x1b[1m    d8:       ::88b.
-\x1b[1m   d8\"         'Y88b
-\x1b[1m  :8P           :888
-\x1b[1m   8a.         _a88P
+\x1b[1m      d/      `8b.\x1b[0m
+\x1b[1m     dP        Y8b.\x1b[0m
+\x1b[1m    d8:       ::88b.\x1b[0m
+\x1b[1m   d8\"         'Y88b\x1b[0m
+\x1b[1m  :8P           :888\x1b[0m
+\x1b[1m   8a.         _a88P\x1b[0m
 \x1b[1m \x1b[93;1m._/\"Y\x1b[0maa     .\x1b[93;1m|\x1b[0m 88P\x1b[93;1m|\x1b[0m
 \x1b[1m \x1b[93;1m\\    Y\x1b[0mP\"    `\x1b[93;1m|     `.\x1b[0m
 \x1b[1m \x1b[93;1m/     \\\x1b[0m.___.d\x1b[93;1m|    .'\x1b[0m

--- a/src/logo.rs
+++ b/src/logo.rs
@@ -1,6 +1,12 @@
 use phf::phf_map;
 use strum_macros::{self, Display, EnumCount, EnumString};
 
+// These are the supported logos. To add a new logo,
+// 1. Add a variant to this enum
+// 2. Add a corresponding entry to the `LOGOS` map.
+//    The key of the entry will be a `&'static str` that represents the name of
+//    the enum variant, preserving the case, e.g. the variant `Logo::MacOS`
+//    corresponds to `"MacOs"`.
 #[derive(Debug, Display, PartialEq, Eq, EnumString, EnumCount)]
 pub enum Logo {
     Deb,

--- a/src/logo.rs
+++ b/src/logo.rs
@@ -204,11 +204,13 @@ mod test {
     fn test_logos_reset_sgr() {
         super::LOGOS.entries().for_each(|(name, logo)| {
             logo.lines().enumerate().for_each(|(line_no, l)| {
-                if l.is_empty() {
+                let sgr_only = crate::ansi::truncate(l, 0);
+                if sgr_only.is_empty() {
                     return;
                 }
+
                 assert!(
-                    crate::ansi::truncate(l, 0).ends_with("\x1b[0m"),
+                    sgr_only.ends_with("\x1b[0m"),
                     "line {} of logo {:?} did not reset SGR. Please terminate it with \"\\x1b[0m\"",
                     line_no,
                     name,

--- a/src/logo.rs
+++ b/src/logo.rs
@@ -1,7 +1,21 @@
-pub fn get_logo_by_distro(sys_name: &str) -> String {
-    match sys_name {
-        "deb" => String::from(
-            "
+use phf::phf_map;
+use strum_macros::{self, Display, EnumCount, EnumString};
+
+#[derive(Debug, Display, PartialEq, Eq, EnumString, EnumCount)]
+pub enum Logo {
+    Deb,
+    Ubuntu,
+    Fedora,
+    Mac,
+    Win11,
+    Win,
+    Arch,
+    Redhat,
+    Linux,
+}
+
+static LOGOS: phf::Map<&'static str, &'static str> = phf_map! {
+    "Deb" => "
 \x1b[1m       _,.ss$$$$$gg.\x1b[0m
 \x1b[1m    ,g$$$$$$$$$$$$$$$P.\x1b[0m
 \x1b[1m  ,g$$P`'     ```Y$$.`.\x1b[0m
@@ -18,11 +32,8 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[1m    `$$b.\x1b[0m
 \x1b[1m       `Y$$b.\x1b[0m
 \x1b[1m          ``Y$b._\x1b[0m
-\x1b[1m              ```\x1b[0m
-            ",
-        ),
-        "ubuntu" => String::from(
-            "
+\x1b[1m              ```\x1b[0m",
+    "Ubuntu" => "
 \x1b[1m                        \x1b[91;1m./+o+-\x1b[0m
 \x1b[1m                yyyyy- \x1b[91;1m-yyyyyy+\x1b[0m
 \x1b[1m             ://+//////\x1b[91;1m-yyyyyyo\x1b[0m
@@ -40,11 +51,8 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[1m          \x1b[93;1m.o:\x1b[0m`\x1b[91;1m.syhhhhhhh/\x1b[0m\x1b[93;1m.oo++o`\x1b[0m
 \x1b[1m              \x1b[91;1m/osyyyyyyo\x1b[93;1m++ooo+++/\x1b[0m
 \x1b[1m                  \x1b[91;1m`````\x1b[0m \x1b[93;1m+oo+++o\\:\x1b[0m
-\x1b[1m                         \x1b[93;1m`oo++.\x1b[0m
-                ",
-        ),
-        "fedora" => String::from(
-            "
+\x1b[1m                         \x1b[93;1m`oo++.\x1b[0m",
+    "Fedora" => "
 \x1b[94;1m             .',;::::;,'.\x1b[0m
 \x1b[94;1m         .';:cccccccccccc:;,.\x1b[0m
 \x1b[94;1m      .;cccccccccccccccccccccc;.\x1b[0m
@@ -64,9 +72,7 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[94;1m:cccccccccccccccccccccccccccc:'.\x1b[0m
 \x1b[94;1m.:cccccccccccccccccccccc:;,..\x1b[0m
 \x1b[94;1m  '::cccccccccccccc::;,.\x1b[0m",
-        ),
-        "mac" => String::from(
-            "
+    "Mac" => "
 \x1b[92;1m                   'c.\x1b[0m
 \x1b[92;1m                ,xNMM.\x1b[0m
 \x1b[92;1m              .OMMMMo\x1b[0m
@@ -83,11 +89,8 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[95;1m .XMMMMMMMMMMMMMMMMMMMMMMMMK.\x1b[0m
 \x1b[94;1m   kMMMMMMMMMMMMMMMMMMMMMMd\x1b[0m
 \x1b[94;1m    ;KMMMMMMMWXXWMMMMMMMk.\x1b[0m
-\x1b[94;1m      .cooc,.    .,coo:.\x1b[0m
-                ",
-        ),
-        "win11" => String::from(
-            "
+\x1b[94;1m      .cooc,.    .,coo:.\x1b[0m",
+    "Win11" => "
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
@@ -103,9 +106,7 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m
 \x1b[34;1mlllllllllllllll   lllllllllllllll\x1b[0m",
-        ),
-        "win" => String::from(
-            "
+    "Win" => "
 \x1b[34m                  .oodMMMMMMMMMMMM\x1b[0m
 \x1b[34m      ..oodMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
 \x1b[34moodMMMMMMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
@@ -123,30 +124,26 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[34m`^^^^^^MMMMMMM  MMMMMMMMMMMMMMMMMM\x1b[0m
 \x1b[34m    ````^^^^  ^^MMMMMMMMMMMMMMMMMM\x1b[0m
 \x1b[34m                  ````^^^^^^MMMMMM\x1b[0m",
-        ),
-        "arch" => String::from(
-            "
- \x1b[94;1m                 ##                 \x1b[0m
- \x1b[94;1m                ####                \x1b[0m
- \x1b[94;1m               ######               \x1b[0m
- \x1b[94;1m              ########              \x1b[0m
- \x1b[94;1m             ##########             \x1b[0m
- \x1b[94;1m            ############            \x1b[0m
- \x1b[94;1m           ##############           \x1b[0m
- \x1b[94;1m          ################          \x1b[0m
- \x1b[94;1m         ##################         \x1b[0m
- \x1b[94;1m        ####################        \x1b[0m
- \x1b[94;1m       ######################       \x1b[0m
- \x1b[94;1m      #########      #########      \x1b[0m
- \x1b[94;1m     ##########      ##########     \x1b[0m
- \x1b[94;1m    ###########      ###########    \x1b[0m
- \x1b[94;1m   ##########          ##########   \x1b[0m
- \x1b[94;1m  #######                  #######  \x1b[0m
- \x1b[94;1m ####                          #### \x1b[0m
- \x1b[94;1m###                              ###\x1b[0m",
-        ),
-        "redhat" => String::from(
-            "
+    "Arch" => "
+\x1b[94;1m                 ##                 \x1b[0m
+\x1b[94;1m                ####                \x1b[0m
+\x1b[94;1m               ######               \x1b[0m
+\x1b[94;1m              ########              \x1b[0m
+\x1b[94;1m             ##########             \x1b[0m
+\x1b[94;1m            ############            \x1b[0m
+\x1b[94;1m           ##############           \x1b[0m
+\x1b[94;1m          ################          \x1b[0m
+\x1b[94;1m         ##################         \x1b[0m
+\x1b[94;1m        ####################        \x1b[0m
+\x1b[94;1m       ######################       \x1b[0m
+\x1b[94;1m      #########      #########      \x1b[0m
+\x1b[94;1m     ##########      ##########     \x1b[0m
+\x1b[94;1m    ###########      ###########    \x1b[0m
+\x1b[94;1m   ##########          ##########   \x1b[0m
+\x1b[94;1m  #######                  #######  \x1b[0m
+\x1b[94;1m ####                          #### \x1b[0m
+\x1b[94;1m###                              ###\x1b[0m",
+    "Redhat" => "
 \x1b[31;1m\x1b[0m
 \x1b[31;1m             ..   .:..\x1b[0m
 \x1b[31;1m           .:::::::::::::..\x1b[0m
@@ -162,9 +159,7 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[31;1m             ..::::::::::::::::::.\x1b[0m
 \x1b[31;1m                  ....:::::...\x1b[0m
 \x1b[31;1m\x1b[0m",
-        ),
-        "linux" => String::from(
-            "
+    "Linux" => "
 \x1b[1m        a8888b.\x1b[0m
 \x1b[1m       d888888b.\x1b[0m
 \x1b[1m       8P\"YP\"Y88\x1b[0m
@@ -180,9 +175,45 @@ pub fn get_logo_by_distro(sys_name: &str) -> String {
 \x1b[1m \x1b[93;1m._/\"Y\x1b[0maa     .\x1b[93;1m|\x1b[0m 88P\x1b[93;1m|\x1b[0m
 \x1b[1m \x1b[93;1m\\    Y\x1b[0mP\"    `\x1b[93;1m|     `.\x1b[0m
 \x1b[1m \x1b[93;1m/     \\\x1b[0m.___.d\x1b[93;1m|    .'\x1b[0m
-\x1b[93;1m `--..__)     `._.'\x1b[0m
-    ",
-        ),
-        _ => String::from(""),
+\x1b[93;1m `--..__)     `._.'\x1b[0m",
+};
+
+pub fn get_logo_by_distro(logo: Logo) -> String {
+    LOGOS[&logo.to_string()].to_string()
+}
+
+mod test {
+    #[test]
+    fn test_logos_keys_match_enum() {
+        use std::str::FromStr;
+        use strum::EnumCount;
+        assert!(
+            super::LOGOS.len() == super::Logo::COUNT,
+            "The number of LOGOS keys is not the same as the number of Logo variants",
+        );
+        super::LOGOS.keys().for_each(|key| {
+            assert!(
+                super::Logo::from_str(key).is_ok(),
+                "LOGOS key {:?} is not a Logo enum variant",
+                key,
+            );
+        });
+    }
+
+    #[test]
+    fn test_logos_reset_sgr() {
+        super::LOGOS.entries().for_each(|(name, logo)| {
+            logo.lines().enumerate().for_each(|(line_no, l)| {
+                if l.is_empty() {
+                    return;
+                }
+                assert!(
+                    crate::ansi::truncate(l, 0).ends_with("\x1b[0m"),
+                    "line {} of logo {:?} did not reset SGR. Please terminate it with \"\\x1b[0m\"",
+                    line_no,
+                    name,
+                );
+            });
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,74 +20,73 @@ fn generate_info(ctx: cli::Ctx) {
     // Update all information of `System` struct.
     sys.refresh_all();
 
-    // Fetch system information:
-    let user_prompt = scanner::get_user_prompt(&sys, &ctx);
-    let sys_name = scanner::get_sys_name(&sys);
-    let host_name = scanner::get_host_name(&sys);
-    let uptime = scanner::get_uptime(&sys);
-    let kernel = scanner::get_kernel(&sys);
-    let os_ver = scanner::get_os_ver(&sys);
-    let cpu_num = Some(format!(
-        "\x1b[93;1m{}\x1b[0m: {}",
-        "NB CPUs",
-        sys.cpus().len()
-    ));
-    let cpu_name = scanner::get_cpu_name(&sys);
-    let gpu_name = scanner::get_gpu_name(&sys);
-    let mem_info = scanner::get_mem_info(&sys);
-    let palette = scanner::get_palette();
-    let palette_lines = palette.as_slice().iter();
-
     let logo = scanner::get_logo(&sys);
     let logo_col = logo.unwrap_or_else(|| "".into());
     let logo_width = logo_col.lines().map(|s| ansi::len(s)).max().unwrap_or(0);
+
     let term_width = termsize::get().map(|w| w.cols).unwrap_or(80);
     let info_width = usize::from(term_width)
         .saturating_sub(logo_width)
         .saturating_sub(4); // includes width of column border plus 1 extra
-
-    // Structure and output system information
-    let sys_info_col = if !ctx.args.minimal {
-        [
-            Some("\n".to_owned()),
-            user_prompt,
-            sys_name,
-            host_name,
-            uptime,
-            kernel,
-            os_ver,
-            cpu_num,
-            cpu_name,
-            gpu_name,
-            mem_info,
-        ]
-        .iter()
-        .flatten()
-        .chain(palette_lines)
-        .map(|s| ansi::truncate(&s, info_width))
-        .collect::<Vec<String>>()
-        .join("\n")
-    } else {
-        vec![user_prompt]
-            .into_iter()
-            .flatten()
-            .collect::<Vec<String>>()
-            .join("\n")
-    };
 
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_CLEAN);
 
     // Check ctx and generate according tables
     if ctx.args.no_logo {
+        let sys_info_col = full_sys_info_col(&sys, &ctx, info_width);
         table.add_row(row![&sys_info_col]);
     } else if ctx.args.minimal {
+        let sys_info_col = minimal_sys_info_col(&sys, ctx);
         table.add_row(row![&logo_col]);
         table.add_row(row![&sys_info_col]);
     } else if ctx.args.logo_only {
         table.add_row(row![&logo_col]);
     } else {
+        let sys_info_col = full_sys_info_col(&sys, &ctx, info_width);
         table.add_row(row![&logo_col, &sys_info_col]);
     }
     table.printstd();
+}
+
+fn full_sys_info_col(sys: &System, ctx: &cli::Ctx, info_width: usize) -> String {
+    let user_prompt = scanner::get_user_prompt(sys, &ctx);
+    let sys_name = scanner::get_sys_name(sys);
+    let host_name = scanner::get_host_name(sys);
+    let uptime = scanner::get_uptime(sys);
+    let kernel = scanner::get_kernel(sys);
+    let os_ver = scanner::get_os_ver(sys);
+    let cpu_num = Some(format!(
+        "\x1b[93;1m{}\x1b[0m: {}",
+        "NB CPUs",
+        sys.cpus().len()
+    ));
+    let cpu_name = scanner::get_cpu_name(sys);
+    let gpu_name = scanner::get_gpu_name(sys);
+    let mem_info = scanner::get_mem_info(sys);
+    let palette = scanner::get_palette();
+    let palette_lines = palette.as_slice().iter();
+
+    [
+        user_prompt,
+        sys_name,
+        host_name,
+        uptime,
+        kernel,
+        os_ver,
+        cpu_num,
+        cpu_name,
+        gpu_name,
+        mem_info,
+    ]
+    .iter()
+    .flatten()
+    .chain(palette_lines)
+    .map(|s| ansi::truncate(&s, info_width))
+    .collect::<Vec<String>>()
+    .join("\n")
+}
+
+fn minimal_sys_info_col(sys: &System, ctx: &cli::Ctx) -> String {
+    scanner::get_user_prompt(sys, ctx).unwrap_or_else(|| "".into())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
+use prettytable::{format, row, Table};
 use sysinfo::{System, SystemExt};
 
-use prettytable::{format, row, Table};
-
+mod ansi;
 mod cli;
 mod logo;
 mod scanner;
@@ -36,11 +36,13 @@ fn generate_info(ctx: cli::Ctx) {
     let gpu_name = scanner::get_gpu_name(&sys);
     let mem_info = scanner::get_mem_info(&sys);
     let palette = scanner::get_palette();
+    let palette_lines = palette.as_slice().iter();
+
     let logo = scanner::get_logo(&sys);
 
     // Structure and output system information
     let sys_info_col = if !ctx.args.minimal {
-        vec![
+        [
             Some("\n".to_owned()),
             user_prompt,
             sys_name,
@@ -52,10 +54,11 @@ fn generate_info(ctx: cli::Ctx) {
             cpu_name,
             gpu_name,
             mem_info,
-            palette,
         ]
-        .into_iter()
+        .iter()
         .flatten()
+        .chain(palette_lines)
+        .map(|s| ansi::truncate(&s, 80))
         .collect::<Vec<String>>()
         .join("\n")
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,8 @@ fn generate_info(ctx: cli::Ctx) {
     let logo_col = logo.unwrap_or_else(|| "".into());
     let logo_width = logo_col.lines().map(|s| ansi::len(s)).max().unwrap_or(0);
 
-    let term_width = termsize::get().map(|w| w.cols).unwrap_or(80);
-    let info_width = usize::from(term_width)
-        .saturating_sub(logo_width)
-        .saturating_sub(4); // includes width of column border plus 1 extra
+    // includes width of column border plus 1 extra
+    let info_width = ctx.width.saturating_sub(logo_width).saturating_sub(4);
 
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_CLEAN);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,11 @@ fn generate_info(ctx: &cli::Ctx) -> Result<(), Box<dyn std::error::Error>> {
 
     str::from_utf8(&buf)?
         .lines()
-        .map(|s| ansi::truncate(s, ctx.width))
-        .for_each(|s| println!("{}", s));
+        .map(|s| match ctx.width {
+            Some(width) => ansi::truncate(s, width),
+            None => s.to_owned(),
+        })
+        .for_each(|s| println!("{s}"));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,12 @@ fn generate_info(ctx: cli::Ctx) {
     let palette_lines = palette.as_slice().iter();
 
     let logo = scanner::get_logo(&sys);
+    let logo_col = logo.unwrap_or_else(|| "".into());
+    let logo_width = logo_col.lines().map(|s| ansi::len(s)).max().unwrap_or(0);
+    let term_width = termsize::get().map(|w| w.cols).unwrap_or(80);
+    let info_width = usize::from(term_width)
+        .saturating_sub(logo_width)
+        .saturating_sub(4); // includes width of column border plus 1 extra
 
     // Structure and output system information
     let sys_info_col = if !ctx.args.minimal {
@@ -58,7 +64,7 @@ fn generate_info(ctx: cli::Ctx) {
         .iter()
         .flatten()
         .chain(palette_lines)
-        .map(|s| ansi::truncate(&s, 80))
+        .map(|s| ansi::truncate(&s, info_width))
         .collect::<Vec<String>>()
         .join("\n")
     } else {
@@ -68,8 +74,6 @@ fn generate_info(ctx: cli::Ctx) {
             .collect::<Vec<String>>()
             .join("\n")
     };
-
-    let logo_col = logo.unwrap_or_else(|| "".into());
 
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_CLEAN);

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -364,15 +364,17 @@ pub fn get_mem_info(sys: &System) -> Option<String> {
     Some(mem_info)
 }
 
-pub fn get_palette() -> Option<String> {
-    let palette = "\n\
-        \x1b[30m███\x1b[0m\x1b[31m███\x1b[0m\x1b[32m███\x1b[0m\x1b[33m███\x1b[0m\
-        \x1b[34m███\x1b[0m\x1b[35m███\x1b[0m\x1b[36m███\x1b[0m\x1b[90;1m███\x1b[0m\n\
-        \x1b[90;1m███\x1b[0m\x1b[91;1m███\x1b[0m\x1b[92;1m███\x1b[0m\x1b[93;1m███\x1b[0m\
-        \x1b[94;1m███\x1b[0m\x1b[95;1m███\x1b[0m\x1b[96;1m███\x1b[0m\x1b[100;1m███\x1b[0m\
-        "
-    .to_string();
-    Some(palette)
+pub fn get_palette() -> Vec<String> {
+    vec![
+        "",
+        "\x1b[30m███\x1b[0m\x1b[31m███\x1b[0m\x1b[32m███\x1b[0m\x1b[33m███\x1b[0m\
+        \x1b[34m███\x1b[0m\x1b[35m███\x1b[0m\x1b[36m███\x1b[0m\x1b[90;1m███\x1b[0m",
+        "\x1b[90;1m███\x1b[0m\x1b[91;1m███\x1b[0m\x1b[92;1m███\x1b[0m\x1b[93;1m███\x1b[0m\
+        \x1b[94;1m███\x1b[0m\x1b[95;1m███\x1b[0m\x1b[96;1m███\x1b[0m\x1b[100;1m███\x1b[0m",
+    ]
+    .into_iter()
+    .map(|s| s.to_string())
+    .collect()
 }
 
 fn get_mac_friendly_name(untrimmed_ver_num: String) -> String {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -30,31 +30,32 @@ lazy_static! {
 
 pub fn get_logo(sys: &System) -> Option<String> {
     sys.name().map(|sys_name| {
+        use crate::logo::Logo::*;
         if sys_name.contains("Windows") {
             if let Some(kernel) = sys.kernel_version() {
                 let float_kernel = kernel.parse::<i32>().unwrap();
                 if float_kernel > 22000 {
-                    get_logo_by_distro("win11")
+                    get_logo_by_distro(Win11)
                 } else {
-                    get_logo_by_distro("win")
+                    get_logo_by_distro(Win)
                 }
             } else {
-                get_logo_by_distro("win")
+                get_logo_by_distro(Win)
             }
         } else if sys_name.contains("Debian") {
-            get_logo_by_distro("deb")
+            get_logo_by_distro(Deb)
         } else if sys_name.contains("Ubuntu") {
-            get_logo_by_distro("ubuntu")
+            get_logo_by_distro(Ubuntu)
         } else if sys_name.contains("Fedora") {
-            get_logo_by_distro("fedora")
+            get_logo_by_distro(Fedora)
         } else if sys_name.contains("Arch") {
-            get_logo_by_distro("arch")
+            get_logo_by_distro(Arch)
         } else if sys_name.contains("Red Hat") {
-            get_logo_by_distro("redhat")
+            get_logo_by_distro(Redhat)
         } else if sys_name.contains("Darwin") || sys_name.contains("Mac") {
-            get_logo_by_distro("mac")
+            get_logo_by_distro(Mac)
         } else {
-            get_logo_by_distro("linux")
+            get_logo_by_distro(Linux)
         }
     })
 }


### PR DESCRIPTION
When the terminal is narrower than the width of the output, currently, the default mode experiences line wrapping, which does not look great:
![2023-12-27-15-54-52](https://github.com/nidnogg/zeitfetch/assets/11096602/28f1f0e0-3958-49d4-bfa6-40b304a771d8)

In contrast, neofetch truncates each line to the width of the terminal:
![2023-12-29-19-42-54](https://github.com/nidnogg/zeitfetch/assets/11096602/fab3459b-e187-4dd5-a2f3-e2be0c36b7ca)

This PR causes zeitfetch to have the same behaviour:
![2023-12-29-19-44-00](https://github.com/nidnogg/zeitfetch/assets/11096602/22e039e5-1013-4b9a-8497-4bf28275c3da)

To do this, I had to implement a truncate function that ignores but preserves ANSI SGR escape codes. I couldn't find one that behaves precisely the way I wanted, in particular, my implementation will preserve all ANSI SGRs in the input, even if they are past the truncation point.

This lead me to notice that some of the logos don't reset the SGR `\x1b[0m` on each line, which I think is important because now the logo lines and the sysinfo lines are combined, so if the logo does not reset the graphics, the sysinfo line could be affected. So I've terminated each logo with `\x1b[0m` where necessary.

Note: the width detection may not work on all terminals. I've noticed kitty on hyprland has this issue: https://github.com/kovidgoyal/kitty/issues/6530 which I've seen affecting the code in this PR. However, I still think this PR is worth merging because:
1. Not all terminals have this issue on hyprland, I've tested alacritty and wezterm, and they seem to work fine.
2. The solution for kitty (add a signal handler for SIGWINCH and wait for at least one before displaying the output) seems overly complex for an application like zeitfetch, is likely to lengthen the runtime, and there's no guarantee a SIGWINCH will be sent or caught in time.

I can have a go at implementing with some heuristic on how long to wait for a SIGWINCH if there is sufficient demand, but without it, it seems we only loose truncation for kitty on some window managers. The output will still be displayed without truncation, so nothing has been taken away from kitty users.