### PR TITLE
Force-enable ANSI color processing on Windows.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,4 +960,5 @@ dependencies = [
  "sysinfo",
  "termsize",
  "unicode-segmentation",
+ "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,8 @@ sysinfo = "0.28.2"
 termsize = "0.1.6"
 unicode-segmentation = "1.10.1"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["processenv"] }
+
 [dev-dependencies]
 rstest = "0.18.2"

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,0 +1,31 @@
+// Windows doesn't always have ANSI color processing enabled by default.
+// This function attempts to safely force-enable it.
+pub fn try_prepare_colors() -> bool {
+    #[cfg(windows)] {
+        if cfg!(target_os = "windows") {
+            use winapi::um::wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            use winapi::um::winbase::STD_OUTPUT_HANDLE;
+            use winapi::um::processenv::GetStdHandle;
+            use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+
+            unsafe {
+                let console_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+                let mut current_mode: u32 = 0;
+
+                if console_handle == std::ptr::null_mut() {
+                    return false;
+                }
+
+                if 0 == GetConsoleMode(console_handle, &mut current_mode) {
+                    return false;
+                }
+
+                if 0 == SetConsoleMode(console_handle, current_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    true
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,11 @@ mod ansi;
 mod cli;
 mod logo;
 mod scanner;
+mod console;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    _ = console::try_prepare_colors();
+
     let ctx = cli::Ctx::new();
     generate_info(&ctx)?;
 


### PR DESCRIPTION
Resolves #12.
The added `winapi` dependency was already required by already present dependencies afaik, so it isn't new.
Let me know if anything about this flow can be prettified.

Test with `VirtualTerminalLevel` registry key set to `0`: ![image](https://github.com/nidnogg/zeitfetch/assets/6795251/e39027f0-beb8-4fdd-a34c-97f9b60a056d)