### PR TITLE
Temporary fix to an issue where ANSI truncates to 0 by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "zeitfetch"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "home",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeitfetch"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["Henrique V (nidnogg)"]
 description = "Instantaneous snapshots of cross-platform system information"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::{env, process::exit};
+extern crate termsize;
 
 const ASCII_LOGO: &str = r"
          _ _    __     _       _     
@@ -24,7 +25,13 @@ pub struct Args {
 impl Ctx {
     pub fn new() -> Self {
         let args = Args::parse_args();
-        let width = termsize::get().map(|w| w.cols.into());
+        let width: Option<usize> =
+            termsize::get().map(|w| if w.cols == 0 { 80 } else { w.cols.into() });
+        // TO-DO debug why termsize is unable to set width with cargo build --release. This commented code results in rows 0 cols 0.
+        // See https://github.com/nidnogg/zeitfetch/issues/14 for more details.
+        // termsize::get().map(|size| {
+        //     println!("rows {} cols {}", size.rows, size.cols)
+        //   });
         Ctx { width, args }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,10 @@ fn generate_info(ctx: &cli::Ctx) -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = Vec::new();
     table.print(&mut buf)?;
 
+    // Ansi truncating.
+    // TO-DO debug why termsize is unable to set width with cargo build --release.
+    // See https://github.com/nidnogg/zeitfetch/issues/14 for more details.
+    // println!("{:?}", ctx.width);
     str::from_utf8(&buf)?
         .lines()
         .map(|s| match ctx.width {


### PR DESCRIPTION
This circumvents https://github.com/nidnogg/zeitfetch/issues/14 by providing a fallback default value for terminal width, at the cost of proper ANSI truncating in these cases.

An additional follow-up fix is looking into why `termsize` is not currently working with `cargo build --release` builds.